### PR TITLE
OpenGL 4.1+ Support

### DIFF
--- a/Assets/Scripts/VolumetricLightRenderer.cs
+++ b/Assets/Scripts/VolumetricLightRenderer.cs
@@ -324,9 +324,7 @@ public class VolumetricLightRenderer : MonoBehaviour
     /// </summary>
     public void OnPreRender()
     {
-        Matrix4x4 proj = _camera.projectionMatrix;
-
-        proj = GL.GetGPUProjectionMatrix(proj, true);
+        Matrix4x4 proj = GL.GetGPUProjectionMatrix(_camera.projectionMatrix, true);
 
         _viewProj = proj * _camera.worldToCameraMatrix;
 

--- a/Assets/Scripts/VolumetricLightRenderer.cs
+++ b/Assets/Scripts/VolumetricLightRenderer.cs
@@ -325,20 +325,8 @@ public class VolumetricLightRenderer : MonoBehaviour
     public void OnPreRender()
     {
         Matrix4x4 proj = _camera.projectionMatrix;
-        
-        if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.Direct3D11)
-        {
-            // Invert Y for rendering to a render texture
-            for (int i = 0; i < 4; i++)
-            {
-                proj[1, i] = -proj[1, i];
-            }
-            // Scale and bias from OpenGL -> D3D depth range
-            for (int i = 0; i < 4; i++)
-            {
-                proj[2, i] = proj[2, i] * 0.5f + proj[3, i] * 0.5f;
-            }
-        }
+
+        proj = GL.GetGPUProjectionMatrix(proj, true);
 
         _viewProj = proj * _camera.worldToCameraMatrix;
 

--- a/Assets/Shaders/VolumetricLight.shader
+++ b/Assets/Shaders/VolumetricLight.shader
@@ -102,7 +102,7 @@ Shader "Sandbox/VolumetricLight"
 			float3 fromCenter2 = wpos.xyz - unity_ShadowSplitSpheres[2].xyz;
 			float3 fromCenter3 = wpos.xyz - unity_ShadowSplitSpheres[3].xyz;
 			float4 distances2 = float4(dot(fromCenter0, fromCenter0), dot(fromCenter1, fromCenter1), dot(fromCenter2, fromCenter2), dot(fromCenter3, fromCenter3));
-#if !defined(SHADER_API_D3D11)
+#if SHADER_TARGET > 30
 			fixed4 weights = float4(distances2 < unity_ShadowSplitSqRadii);
 			weights.yzw = saturate(weights.yzw - weights.xyz);
 #else
@@ -116,7 +116,7 @@ Shader "Sandbox/VolumetricLight"
 		//-----------------------------------------------------------------------------------------
 		inline float4 GetCascadeShadowCoord(float4 wpos, fixed4 cascadeWeights)
 		{
-#if defined(SHADER_API_D3D11)
+#if SHADER_TARGET > 30
 			return mul(unity_World2Shadow[(int)dot(cascadeWeights, float4(1, 1, 1, 1))], wpos);
 #else
 			float3 sc0 = mul(unity_World2Shadow[0], wpos).xyz;

--- a/Assets/Shaders/VolumetricLight.shader
+++ b/Assets/Shaders/VolumetricLight.shader
@@ -359,7 +359,7 @@ Shader "Sandbox/VolumetricLight"
 			CGPROGRAM
 			#pragma vertex vert
 			#pragma fragment fragPointInside
-#pragma target 5.0
+			#pragma target gl4.1
 
 			#define UNITY_HDR_ON
 
@@ -408,7 +408,7 @@ Shader "Sandbox/VolumetricLight"
 			CGPROGRAM
 #pragma vertex vert
 #pragma fragment fragPointInside
-#pragma target 5.0
+#pragma target gl4.1
 
 #define UNITY_HDR_ON
 
@@ -456,7 +456,7 @@ Shader "Sandbox/VolumetricLight"
 			CGPROGRAM
 			#pragma vertex vert
 			#pragma fragment fragPointOutside
-			#pragma target 5.0
+			#pragma target gl4.1
 
 			#define UNITY_HDR_ON
 
@@ -513,7 +513,7 @@ Shader "Sandbox/VolumetricLight"
 			CGPROGRAM
 			#pragma vertex vert
 			#pragma fragment fragSpotOutside
-#pragma target 5.0
+			#pragma target gl4.1
 
 			#define UNITY_HDR_ON
 
@@ -577,7 +577,7 @@ Shader "Sandbox/VolumetricLight"
 
 #pragma vertex vert
 #pragma fragment fragDir
-#pragma target 5.0
+#pragma target gl4.1
 
 #define UNITY_HDR_ON
 


### PR DESCRIPTION
This adds OpenGL 4.1+ support. Using GL.GetGPUProjectionMatrix ensures that the projection matrix will match the one used by the GPU regardless of platform/API. Other than that some of the pragma targets were changed to gl4.1 to allow the shaders to compile. Besides that everything seems to work as is!

Not tested on Linux or Mac, but working on Windows with -force-glcore41 which is the OpenGL version on Mac.