### PR TITLE
Fix VR usage: use camera projection matrix by current camera

### DIFF
--- a/Assets/Scripts/VolumetricLight.cs
+++ b/Assets/Scripts/VolumetricLight.cs
@@ -358,7 +358,9 @@ public class VolumetricLight : MonoBehaviour
 
             _material.EnableKeyword("SHADOWS_DEPTH");
             _commandBuffer.SetGlobalTexture("_ShadowMapTexture", BuiltinRenderTextureType.CurrentActive);
-            renderer.GlobalCommandBuffer.DrawMesh(mesh, world, _material, 0, pass);
+            _commandBuffer.SetRenderTarget(renderer.GetVolumeLightBuffer());
+
+            _commandBuffer.DrawMesh(mesh, world, _material, 0, pass);
 
             if (CustomRenderEvent != null)
                 CustomRenderEvent(renderer, this, _commandBuffer, viewProj);       

--- a/Assets/Scripts/VolumetricLight.cs
+++ b/Assets/Scripts/VolumetricLight.cs
@@ -358,9 +358,7 @@ public class VolumetricLight : MonoBehaviour
 
             _material.EnableKeyword("SHADOWS_DEPTH");
             _commandBuffer.SetGlobalTexture("_ShadowMapTexture", BuiltinRenderTextureType.CurrentActive);
-            _commandBuffer.SetRenderTarget(renderer.GetVolumeLightBuffer());
-
-            _commandBuffer.DrawMesh(mesh, world, _material, 0, pass);
+            renderer.GlobalCommandBuffer.DrawMesh(mesh, world, _material, 0, pass);
 
             if (CustomRenderEvent != null)
                 CustomRenderEvent(renderer, this, _commandBuffer, viewProj);       

--- a/Assets/Scripts/VolumetricLightRenderer.cs
+++ b/Assets/Scripts/VolumetricLightRenderer.cs
@@ -270,8 +270,18 @@ public class VolumetricLightRenderer : MonoBehaviour
     public void OnPreRender()
     {
 
-        // use very low value for near clip plane to simplify cone/frustum intersection 
-        Matrix4x4 proj = GL.GetGPUProjectionMatrix(Camera.current.projectionMatrix, true);
+        // use very low value for near clip plane to simplify cone/frustum intersection
+        Matrix4x4 proj = Matrix4x4.Perspective(_camera.fieldOfView, _camera.aspect, 0.01f, _camera.farClipPlane);
+
+#if UNITY_2017_2_OR_NEWER
+        if (UnityEngine.XR.XRSettings.enabled)
+        {
+            // when using VR override the used projection matrix
+            proj = Camera.current.projectionMatrix;
+        }
+#endif
+
+        proj = GL.GetGPUProjectionMatrix(proj, true);
         _viewProj = proj * _camera.worldToCameraMatrix;
 
         _preLightPass.Clear();

--- a/Assets/Scripts/VolumetricLightRenderer.cs
+++ b/Assets/Scripts/VolumetricLightRenderer.cs
@@ -269,10 +269,9 @@ public class VolumetricLightRenderer : MonoBehaviour
     /// </summary>
     public void OnPreRender()
     {
-        // use very low value for near clip plane to simplify cone/frustum intersection 
-        Matrix4x4 proj = Matrix4x4.Perspective(_camera.fieldOfView, _camera.aspect, 0.01f, _camera.farClipPlane);
-        proj = GL.GetGPUProjectionMatrix(proj, true);
 
+        // use very low value for near clip plane to simplify cone/frustum intersection 
+        Matrix4x4 proj = GL.GetGPUProjectionMatrix(Camera.current.projectionMatrix, true);
         _viewProj = proj * _camera.worldToCameraMatrix;
 
         _preLightPass.Clear();


### PR DESCRIPTION
This is a solution for the VR-issue described by users. It was tested using HTC Vive in Unity 2017. 

<img width="922" alt="vr_issue" src="https://user-images.githubusercontent.com/680380/32732262-48d0c34e-c88c-11e7-972b-c2b987db029b.png">
<img width="921" alt="vr_issue_fixed" src="https://user-images.githubusercontent.com/680380/32732263-48fce668-c88c-11e7-868c-3af7c00283ea.png">
